### PR TITLE
Allow end user to customize rendering behavior when a callout has no title.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.ts]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # markdown-it-callouts
 
-A simple `markdown-it` plugin that adds support for [Obsidian callouts](https://help.obsidian.md/Editing+and+formatting/Callouts) or [GitHub Flavored Markdown alerts](https://github.com/orgs/community/discussions/16925). 
+A simple `markdown-it` plugin that adds support for [Obsidian callouts](https://help.obsidian.md/Editing+and+formatting/Callouts) or [GitHub Flavored Markdown alerts](https://github.com/orgs/community/discussions/16925).
 
 Given the following markdown:
 
@@ -51,6 +51,14 @@ export interface Config {
    * The element to wrap callout symbols in. Defaults to "span"
    */
   calloutSymbolElementType?: string;
+  /**
+   * - "none": (default) do not render any title.
+   * - "blank": render a blank title (""). Renders the callout-title and callout-symbol containers,
+   *            so you can have a symbol even with no title.
+   * - "match-type": render a title that matches the type of callout. An info callout will have an "Info" title,
+   *                   a note callout will have a "Note" title, etc.
+   */
+  emptyTitleFallback?: "none" | "blank" | "match-type";
 }
 ```
 

--- a/main.test.ts
+++ b/main.test.ts
@@ -87,11 +87,11 @@ test("callout with default config without title generates no title or symbol", (
 `);
 });
 
-test("callout with enableCalloutSymbolWithEmptyType set to no without title generates no title or symbol", () => {
+test("callout with enableCalloutSymbolWithEmptyType set to none without title generates no title or symbol", () => {
   const md = instance({
     calloutSymbolElementType: "div",
     calloutSymbols: { info: "I" },
-    enableCalloutSymbolWithEmptyType: "no",
+    emptyTitleFallback: "none",
   });
   expect(
     md.render(`> [!Info] 
@@ -107,7 +107,7 @@ test("callout with enableCalloutSymbolWithEmptyType set to blank without title g
     calloutSymbolElementType: "div",
     calloutTitleElementType: "div",
     calloutSymbols: { info: "I" },
-    enableCalloutSymbolWithEmptyType: "blank",
+    emptyTitleFallback: "blank",
   });
   expect(
     md.render(`> [!Info] 
@@ -118,12 +118,12 @@ test("callout with enableCalloutSymbolWithEmptyType set to blank without title g
 `);
 });
 
-test("callout with enableCalloutSymbolWithEmptyType set to callout-type without title generates title", () => {
+test("callout with enableCalloutSymbolWithEmptyType set to match-type without title generates title", () => {
   const md = instance({
     calloutSymbolElementType: "div",
     calloutTitleElementType: "div",
     calloutSymbols: { info: "I" },
-    enableCalloutSymbolWithEmptyType: "callout-type",
+    emptyTitleFallback: "match-type",
   });
   expect(
     md.render(`> [!Info] 

--- a/main.test.ts
+++ b/main.test.ts
@@ -133,5 +133,3 @@ test("callout with enableCalloutSymbolWithEmptyType set to callout-type without 
 </div>
 `);
 });
-
-

--- a/main.test.ts
+++ b/main.test.ts
@@ -72,3 +72,66 @@ test("custom element with caps", () => {
 </div>
 `);
 });
+
+test("callout with default config without title generates no title or symbol", () => {
+  const md = instance({
+    calloutSymbolElementType: "div",
+    calloutSymbols: { info: "I" },
+  });
+  expect(
+    md.render(`> [!Info] 
+> Body line 1`)
+  ).toEqual(`<div class="callout callout-info">
+<p>Body line 1</p>
+</div>
+`);
+});
+
+test("callout with enableCalloutSymbolWithEmptyType set to no without title generates no title or symbol", () => {
+  const md = instance({
+    calloutSymbolElementType: "div",
+    calloutSymbols: { info: "I" },
+    enableCalloutSymbolWithEmptyType: "no",
+  });
+  expect(
+    md.render(`> [!Info] 
+> Body line 1`)
+  ).toEqual(`<div class="callout callout-info">
+<p>Body line 1</p>
+</div>
+`);
+});
+
+test("callout with enableCalloutSymbolWithEmptyType set to blank without title generates symbol", () => {
+  const md = instance({
+    calloutSymbolElementType: "div",
+    calloutTitleElementType: "div",
+    calloutSymbols: { info: "I" },
+    enableCalloutSymbolWithEmptyType: "blank",
+  });
+  expect(
+    md.render(`> [!Info] 
+> Body line 1`)
+  ).toEqual(`<div class="callout callout-info">
+<div class="callout-title"><div class="callout-symbol">I</div></div><p>Body line 1</p>
+</div>
+`);
+});
+
+test("callout with enableCalloutSymbolWithEmptyType set to callout-type without title generates title", () => {
+  const md = instance({
+    calloutSymbolElementType: "div",
+    calloutTitleElementType: "div",
+    calloutSymbols: { info: "I" },
+    enableCalloutSymbolWithEmptyType: "callout-type",
+  });
+  expect(
+    md.render(`> [!Info] 
+> Body line 1`)
+  ).toEqual(`<div class="callout callout-info">
+<div class="callout-title"><div class="callout-symbol">I</div>Info</div><p>Body line 1</p>
+</div>
+`);
+});
+
+

--- a/main.ts
+++ b/main.ts
@@ -7,7 +7,7 @@ import type { StateCore, Token } from "markdown-it/index.js";
  * > [!Info]
  * > Callout text here
  *
- * Instead of 
+ * Instead of
  * > [!Info] Title
  * > Callout text here.
  *
@@ -45,7 +45,7 @@ export interface Config {
    */
   calloutSymbolElementType?: string;
   /**
-   * One of the EnableCalloutSymbolOptions. Defaults to "no", where 
+   * One of the EnableCalloutSymbolOptions. Defaults to "no", where
    * no title is rendered.
    * "blank" will render a symbol and a callout-title container but the title will be empty.
    * "callout-title" will insert a title identical to the callout type.
@@ -89,7 +89,6 @@ export default function (md: MarkdownIt, config: Config = {}) {
       closeToken.type = "callout_close";
       closeToken.tag = openToken.tag;
 
-
       if (title) {
         const titleTokens = createTitleTokens(
           state,
@@ -104,22 +103,16 @@ export default function (md: MarkdownIt, config: Config = {}) {
       // Super.
       else {
         if (config.enableCalloutSymbolWithEmptyType === "blank") {
-          const titleTokens = createTitleTokens(
-            state,
-            config,
-            calloutType,
-            ""
-          );
+          const titleTokens = createTitleTokens(state, config, calloutType, "");
           tokens.splice(openIdx + 1, 0, ...titleTokens);
-        }
-        else if (config.enableCalloutSymbolWithEmptyType === "callout-type") {
+        } else if (config.enableCalloutSymbolWithEmptyType === "callout-type") {
           // Returns the callout type as the title with the first letter capitalized.
           const title = prettyFormatCalloutType(calloutType);
           const titleTokens = createTitleTokens(
             state,
             config,
             calloutType,
-            title,
+            title
           );
           tokens.splice(openIdx + 1, 0, ...titleTokens);
         }
@@ -240,8 +233,6 @@ function createTitleTokens(
 /* Takes a string and returns the same string with the first letter capitalized.
  * Assumes that the input string is lowercase.
  */
-function prettyFormatCalloutType(calloutType: string): string
-{
+function prettyFormatCalloutType(calloutType: string): string {
   return calloutType.charAt(0).toUpperCase() + calloutType.slice(1);
 }
-

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "markdown-it": "^14.1.0",
     "typescript": "^5.5.4",
     "vitest": "^2.0.5"
+  },
+  "prettier": {
+      "tabWidth": 2
   }
 }


### PR DESCRIPTION
I wanted the ability to render a symbol with a callout even if my callout has no title. I've added an `EnableCalloutSymbolOptions` type to the configuration which can be one of "no", "blank", or "callout-type".

"no" recreates the pre-existing functionality: if there is no title, no title container or symbol is rendered.

"blank" inserts the title container and symbol but does not include anything for the actual title text itself.

"callout-type" inserts a default title that is the callout type with the first letter capitalized. So an info callout would have an "Info" title, a warning callout would have a "Warning" title, etc.

Shouldn't be a very drastic change, but please feel free to take a look and tell me what you think!